### PR TITLE
chore(button): add ReactNode type of children in component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/react-elements",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Platform Builders Shared Components Library For React Web and Native",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/native/types/Button.ts
+++ b/src/native/types/Button.ts
@@ -1,4 +1,5 @@
 import { StyleProp, ViewStyle, TextStyle } from 'react-native';
+import { ReactNode } from 'react';
 import { ButtonVariants, TypographyVariants } from './Variants';
 import { TouchableType } from './TouchableType';
 
@@ -12,5 +13,5 @@ export type ButtonProps = {
   contrast?: boolean;
   variant?: ButtonVariants;
   typographyVariant?: TypographyVariants;
-  children?: string;
+  children?: string | ReactNode;
 } & TouchableType;


### PR DESCRIPTION
## Descrição do PR

Adicionando `ReactNode` como tipagem possível no componente `Button` do RN.

## Tipo de mudança

- [x] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)

## Checklist 🚨

- [x] Meu código segue o code style da Builders.
- [ ] Testado no Chrome
- [ ] Testado no Firefox
- [ ] Testado no Safari
