### PR TITLE
set in typescript the numberOfLines Text options

### DIFF
--- a/src/native/types/Typography.ts
+++ b/src/native/types/Typography.ts
@@ -27,4 +27,5 @@ export interface TypographyType {
   textRef?: any;
   id?: string;
   accessibility?: string;
+  numberOfLines?: number;
 }


### PR DESCRIPTION
## Descrição do PR

Precisei usar no projeto do Carrefour o numberOfLines do Text para limitar o numero de linhas que o título poderia ter. Mas para isso tive que incluir no type do Typography para ele não acusar erro de sintaxe.

## Screenshots e GIFs

![imagem 1](https://i.ibb.co/WvzP4QC/Captura-de-Tela-2020-12-02-a-s-23-25-08.png) ![imagem 2](https://i.ibb.co/9hWdd9K/Captura-de-Tela-2020-12-02-a-s-23-25-01.png)

## Tipo de mudança

- [x] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)

## Checklist 🚨

- [x] Meu código segue o code style da Builders.
- [x] Testado no iOS
- [x] Testado no Android
