### PR TITLE
fix(input-focus): adding option to skip custom auto focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/react-elements",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Platform Builders Shared Components Library For React Web and Native",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/native/components/TextInput/index.tsx
+++ b/src/native/components/TextInput/index.tsx
@@ -28,6 +28,7 @@ const TextInput: FC<TextInputType> = ({
   borderless = false,
   multiline = false,
   autoFocus = false,
+  customFocus = true,
   allowFontScaling = false,
   keyboardType = 'default',
   iconSize = 20,
@@ -157,15 +158,15 @@ const TextInput: FC<TextInputType> = ({
   };
 
   const focusInputElement = (element: any) => {
-    const delay = isIOS() ? 0 : 5;
+    const delay = isIOS() ? 5 : 15;
     setTimeout(() => {
-      element.focus();
+      element?.focus();
     }, delay);
   };
 
   const checkFocus = () => {
     let element = inputRef?.current;
-    if (autoFocus) {
+    if (autoFocus && customFocus) {
       if (maskType) {
         // eslint-disable-next-line no-underscore-dangle
         element = inputRef?.current?._inputElement;

--- a/src/native/types/TextInputType.ts
+++ b/src/native/types/TextInputType.ts
@@ -30,6 +30,7 @@ export interface TextInputType extends TextInputProps {
   iconHitSlop?: HitSlopType;
   labelStyle?: any;
   isPlaceholder?: boolean;
+  customFocus?: boolean;
   onPressIcon?(x?: any): void;
   onBlur?(x?: any): void;
   onFocus?(x?: any): void;


### PR DESCRIPTION
## Descrição do PR

Adicionada opção de não utilizar o fix/custom auto focus que foi implementado para amenizar o bug do Android.

## Tipo de mudança

- [X] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)

## Checklist 🚨

- [X] Meu código segue o code style da Builders.
- [X] Testado no iOS
- [X] Testado no Android
- [ ] Testado no Chrome
- [ ] Testado no Firefox
- [ ] Testado no Safari
