### PR TITLE
feat: add onFocus and formatChars to mask input

### DIFF
--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -17,9 +17,11 @@ enum Mask {
 const TextInput: FC<TextInputType> = ({
   mask,
   maskType = '',
+  formatChars,
   error = '',
   onChange,
   onBlur,
+  onFocus,
   maxlength,
   ...rest
 }) => {
@@ -30,7 +32,13 @@ const TextInput: FC<TextInputType> = ({
     return maskType === 'currency' ? (
       <CurrencyInput {...rest} onChangeText={onChange} />
     ) : hasMask ? (
-      <TextInputMask mask={maskOption} onChange={onChange} {...rest}>
+      <TextInputMask
+        mask={maskOption}
+        formatChars={formatChars}
+        onChange={onChange}
+        onFocus={onFocus}
+        {...rest}
+      >
         {(inputProps: any): JSX.Element => (
           <Input
             margin="normal"
@@ -45,6 +53,7 @@ const TextInput: FC<TextInputType> = ({
         margin="normal"
         onChange={onChange}
         onBlur={onBlur}
+        onFocus={onFocus}
         error={!!error}
         inputProps={{ maxLength: maxlength }}
       />

--- a/src/types/TextInput.ts
+++ b/src/types/TextInput.ts
@@ -3,6 +3,7 @@ import { ChangeEvent, FocusEvent } from 'react';
 export type TextInputType = {
   mask?: string;
   maskType?: string;
+  formatChars?: { [key: string]: string };
   label?: string;
   error?: string | boolean;
   placeholder?: string;
@@ -19,5 +20,8 @@ export type TextInputType = {
     e:
       | FocusEvent<HTMLInputElement | HTMLTextAreaElement>
       | ChangeEvent<HTMLDivElement>,
+  ) => void;
+  onFocus?: (
+    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void;
 };


### PR DESCRIPTION
## O que foi feito? 📝

Adicionado props de `onFocus` e `formatChars` para o componente de `TextInput`.

## Tipo de mudança 🏗

- [x] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->
- [ ] Testado no iOS
- [ ] Testado no Android
<!-- web -->
- [x] Testado no Chrome
- [ ] Testado no Safari
- [ ] Testado no Firefox
- [ ] Testado no Edge
- [x] Não gerou alerta ou erro no console
