### PR TITLE
chore(accessibility): refactor to use one prop only

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//npm.pkg.github.com/:_authToken=a6f137b28be9c2c5c9f767e6499fa9c50ea34af2
+@platformbuilders:registry=https://npm.pkg.github.com/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/react-elements",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Platform Builders Shared Components Library For React Web and Native",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -65,6 +65,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@platformbuilders/helpers": "^0.3.2",
+    "@platformbuilders/react-native-masked-text": "^1.0.0",
     "@types/react-text-mask": "^5.4.6",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "formik": "^2.1.6",
@@ -79,7 +80,6 @@
     "react-native-haptic": "^1.0.1",
     "react-native-image-picker": "2.3.4",
     "react-native-markdown-display": "^6.1.6",
-    "react-native-masked-text": "duspada/react-native-masked-text",
     "react-native-responsive-fontsize": "^0.4.3",
     "react-native-size-matters": "^0.3.0",
     "react-native-typography": "^1.4.1",

--- a/src/native/components/Avatar/index.tsx
+++ b/src/native/components/Avatar/index.tsx
@@ -17,7 +17,7 @@ type Props = {
   size?: number;
   onPress?: (x: any) => void;
   onUpload?: (x: any) => any;
-  id: string;
+  id?: string;
   accessibility: string;
   accessibilityLabel?: string;
   testID?: string;
@@ -39,6 +39,7 @@ const Avatar: React.FC<Props> = React.forwardRef(
       ...rest
     },
     ref,
+    // eslint-disable-next-line sonarjs/cognitive-complexity
   ) => {
     const [uploadedImage, setUploadedImage] = useState<any>();
     const cameraRef = useRef<any>();
@@ -102,7 +103,7 @@ const Avatar: React.FC<Props> = React.forwardRef(
 
     return (
       <Wrapper
-        id={id}
+        id={id || accessibility}
         accessibility={accessibility}
         accessibilityLabel={accessibilityLabel || accessibility}
         testID={testID || id}

--- a/src/native/components/Button/index.tsx
+++ b/src/native/components/Button/index.tsx
@@ -20,10 +20,10 @@ const Button: FC<ButtonProps> = ({
 }) => {
   return (
     <Touchable
-      id={id}
+      id={id || accessibility}
       accessibility={accessibility}
       accessibilityLabel={accessibilityLabel || accessibility}
-      testID={testID || id}
+      testID={testID || id || accessibility}
       disabled={loading || disabled}
       onPress={onPress}
       rounded={rounded}

--- a/src/native/components/CheckBox/index.tsx
+++ b/src/native/components/CheckBox/index.tsx
@@ -4,7 +4,7 @@ import FormError from '../FormError';
 import { Wrapper, defaultLabelStyle, containerStyle, CheckBox } from './styles';
 
 type Props = {
-  id: string;
+  id?: string;
   accessibility: string;
   checked?: boolean;
   label?: string;
@@ -32,10 +32,14 @@ const CheckboxComponent: FC<Props> = ({
   uncheckedCheckBoxColor,
   style,
 }) => (
-  <FormError id={id} accessibility={accessibility} error={error}>
+  <FormError
+    id={id || accessibility}
+    accessibility={accessibility}
+    error={error}
+  >
     <Wrapper style={style}>
       <CheckBox
-        testID={`check_${id}`}
+        testID={`check_${id || accessibility}`}
         accessibilityLabel={`Check ${accessibility}`}
         style={containerStyle}
         isChecked={checked}

--- a/src/native/components/DatePicker/index.tsx
+++ b/src/native/components/DatePicker/index.tsx
@@ -29,7 +29,7 @@ interface Props {
   format?: string;
   dark?: boolean;
   status?: string;
-  id: string;
+  id?: string;
   accessibility: string;
 }
 
@@ -41,7 +41,7 @@ const DatePickerInput: FC<Props> = ({
   dark = false,
   editable = true,
   value = '',
-  testID = '',
+  testID,
   mode = 'date',
   androidMode = 'spinner',
   locale = 'pt-BR',
@@ -100,7 +100,11 @@ const DatePickerInput: FC<Props> = ({
     : DatePickerStyles;
 
   return (
-    <FormError id={id} accessibility={accessibility} error={error}>
+    <FormError
+      id={id || accessibility}
+      accessibility={accessibility}
+      error={error}
+    >
       <Label
         error={error || ''}
         style={labelAnimatedStyle}
@@ -119,7 +123,7 @@ const DatePickerInput: FC<Props> = ({
         date={date}
         customStyles={customStyles}
         maxDate={maxDate}
-        testID={testID}
+        testID={testID || accessibility}
         confirmBtnText={confirmBtnText}
         cancelBtnText={cancelBtnText}
         onDateChange={updateDate}

--- a/src/native/components/FAB/index.tsx
+++ b/src/native/components/FAB/index.tsx
@@ -5,7 +5,7 @@ import If from '../If';
 import { Wrapper, Icon, Title } from './styles';
 
 type Props = {
-  id: string;
+  id?: string;
   accessibility: string;
   onPress(): void;
   color?: string;
@@ -33,7 +33,7 @@ const FAB: FC<Props> = ({
   ...rest
 }) => (
   <Wrapper
-    id={id}
+    id={id || accessibility}
     accessibility={accessibility}
     onPress={onPress}
     size={size}
@@ -43,14 +43,14 @@ const FAB: FC<Props> = ({
     {...rest}
   >
     <Icon
-      id={id}
+      id={`icon_${id || accessibility}`}
       name={iconName || 'plus'}
       accessibility={accessibility}
       iconColor={iconColor}
       iconSize={iconSize}
     />
     <If condition={!isEmpty(title)}>
-      <Title>{title}</Title>
+      <Title accessibility={title || ''}>{title}</Title>
     </If>
   </Wrapper>
 );

--- a/src/native/components/FormError/index.tsx
+++ b/src/native/components/FormError/index.tsx
@@ -33,6 +33,7 @@ const FormError: FC<Props> = ({
           centered={centered}
           large={large}
           testID={`error_${id}`}
+          accessibility={`Erro ${accessibility || error}`}
           accessibilityLabel={`Erro ${accessibility || error}`}
           {...rest}
         >

--- a/src/native/components/Icon/index.tsx
+++ b/src/native/components/Icon/index.tsx
@@ -27,10 +27,10 @@ export const Icon: FC<IconType> = ({
   return (
     <Animated.View style={style}>
       <Touchable
-        id={id}
+        id={id || accessibility}
         accessibility={accessibility || iconName}
         accessibilityLabel={accessibilityLabel || accessibility}
-        testID={testID || id}
+        testID={testID || id || accessibility}
         disabled={!touchable}
         onPress={onPress}
         {...rest}

--- a/src/native/components/Link/index.tsx
+++ b/src/native/components/Link/index.tsx
@@ -21,16 +21,17 @@ const Link: FC<Props> = ({
   ...rest
 }) => (
   <Touchable
-    id={id}
+    id={id || accessibility}
     onPress={onPress}
     accessibility={accessibility}
     accessibilityLabel={accessibilityLabel || accessibility}
-    testID={testID || id}
+    testID={testID || id || accessibility}
     {...rest}
   >
     <Text
       testID={`text_${id}`}
       accessibilityLabel={`Texto ${accessibility}`}
+      accessibility={`Texto ${accessibility}`}
       style={style}
       variant={variant}
     >

--- a/src/native/components/LoadingIndicator/index.tsx
+++ b/src/native/components/LoadingIndicator/index.tsx
@@ -6,11 +6,12 @@ const Loading: FC<LoadingType> = ({
   large = false,
   contrast = false,
   variant = 'circular',
+  accessibility,
   ...rest
 }) => (
   <Indicator
-    testID="loading"
-    accessibilityLabel="Aguarde"
+    testID={accessibility || 'loading'}
+    accessibilityLabel={accessibility || 'Aguarde'}
     variant={variant}
     contrast={contrast}
     style={large ? largeSize : smallSize}

--- a/src/native/components/PinInput/index.tsx
+++ b/src/native/components/PinInput/index.tsx
@@ -11,6 +11,9 @@ import {
   defaultStyling,
 } from './styles';
 
+const iconString = (hidePassword: boolean): string =>
+  hidePassword ? 'eye' : 'eye-off';
+
 const PinInput: React.FC<PinInputType> = ({
   password = false,
   animated = false,
@@ -56,9 +59,10 @@ const PinInput: React.FC<PinInputType> = ({
         />
         {password && (
           <Icon
-            id="code_input_icon"
-            accessibility="Exibir ou ocultar inputs"
-            name={hidePassword ? 'eye' : 'eye-off'}
+            accessibility={`Exibir ou ocultar inputs - ${iconString(
+              hidePassword,
+            )}`}
+            name={iconString(hidePassword)}
             size={iconSize}
             onPress={() => setHidePassword(!hidePassword)}
             contrast={contrast}
@@ -66,7 +70,11 @@ const PinInput: React.FC<PinInputType> = ({
           />
         )}
       </Wrapper>
-      {!!caption && <CaptionText centered={centered}>{caption}</CaptionText>}
+      {!!caption && (
+        <CaptionText accessibility={caption} centered={centered}>
+          {caption}
+        </CaptionText>
+      )}
     </FormError>
   );
 };

--- a/src/native/components/RadioButton/index.tsx
+++ b/src/native/components/RadioButton/index.tsx
@@ -3,7 +3,7 @@ import If from '../If';
 import { Radio, CheckedRadio } from './styles';
 
 type Props = {
-  id: string;
+  id?: string;
   accessibility: string;
   radioButtonColor?: string;
   checkedRadioButtonColor?: string;
@@ -24,7 +24,7 @@ const RadioButton: React.FC<Props> = ({
   onPress = () => {},
 }) => (
   <Radio
-    id={id}
+    id={id || accessibility}
     accessibility={accessibility}
     onPress={onPress}
     radioButtonColor={radioButtonColor}

--- a/src/native/components/SearchInput/index.tsx
+++ b/src/native/components/SearchInput/index.tsx
@@ -3,7 +3,7 @@ import { Keyboard, StyleProp, TextStyle, ViewStyle } from 'react-native';
 import { Input, Wrapper } from './styles';
 
 type Props = {
-  id: string;
+  id?: string;
   accessibility: string;
   onChange(value: string): void;
   onClear?(): void;
@@ -64,7 +64,7 @@ const SearchInput: React.FC<Props> = ({
         inputRef={ref}
         borderless
         large={false}
-        id={id}
+        id={id || accessibility}
         accessibility={accessibility}
         autoFocus={autoFocus}
         autoCapitalize="none"

--- a/src/native/components/TextInput/MaskedTextInput/index.tsx
+++ b/src/native/components/TextInput/MaskedTextInput/index.tsx
@@ -14,10 +14,10 @@ const MaskedTextInput: FC<MaskedTextInputType> = ({
 }) => (
   <TextInput
     {...props}
-    id={id}
+    id={id || accessibility}
     status={status}
     accessibility={accessibility}
-    testID={id}
+    testID={id || accessibility}
     accessibilityLabel={accessibility}
     ref={inputRef}
     contrast={contrast}

--- a/src/native/components/TextInput/MaskedTextInput/styles.ts
+++ b/src/native/components/TextInput/MaskedTextInput/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components/native';
-import { TextInputMask } from 'react-native-masked-text';
+import { TextInputMask } from '@platformbuilders/react-native-masked-text';
 import { TextInput as TextInputStyle } from '../styles';
 
 const Input = TextInputStyle.withComponent(TextInputMask);

--- a/src/native/components/TextInput/index.tsx
+++ b/src/native/components/TextInput/index.tsx
@@ -139,7 +139,7 @@ const TextInput: FC<TextInputType> = ({
         inputRef={inputRef}
         maskType={maskType || 'no-mask'}
         accessibilityLabel={accessibilityLabel || accessibility}
-        testID={testID || id}
+        testID={testID || id || accessibility}
         {...textInputProps}
       />
     );
@@ -183,7 +183,7 @@ const TextInput: FC<TextInputType> = ({
   return (
     <Wrapper style={style} multiline={multiline}>
       <FormError
-        id={id}
+        id={id || accessibility}
         accessibility={accessibility}
         centered={centered}
         error={error}
@@ -195,7 +195,7 @@ const TextInput: FC<TextInputType> = ({
             contrast={contrast}
             style={[labelAnimatedStyle, labelStyle]}
             variant={isPlaceholder ? placeholderVariant : labelVariant}
-            testID={`error_${id}`}
+            testID={`error_${id || accessibility}`}
             accessibilityLabel={`Erro ${accessibility}`}
           >
             {label}

--- a/src/native/components/Touchable/index.tsx
+++ b/src/native/components/Touchable/index.tsx
@@ -8,13 +8,15 @@ const CommonTouchable: FC<TouchableType> = ({
   haptic = 'impact',
   disabled = false,
   accessibility,
+  accessibilityLabel,
+  testID,
   id,
   ...rest
 }) => (
   <TouchableOpacity
     {...rest}
-    accessibilityLabel={accessibility}
-    testID={id}
+    accessibilityLabel={accessibilityLabel || accessibility}
+    testID={testID || id || accessibility}
     disabled={disabled}
     onPress={(e): void => {
       generateHaptic(haptic);

--- a/src/native/components/Typography/__tests__/Typography.spec.tsx
+++ b/src/native/components/Typography/__tests__/Typography.spec.tsx
@@ -9,7 +9,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for default props', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography />
+        <Typography accessibility="" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -18,7 +18,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant largeTitle', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="largeTitle" />
+        <Typography accessibility="" variant="largeTitle" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -27,7 +27,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant title1', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="title1" />
+        <Typography accessibility="" variant="title1" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -36,7 +36,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant title2', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="title2" />
+        <Typography accessibility="" variant="title2" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -45,7 +45,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant title3', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="title3" />
+        <Typography accessibility="" variant="title3" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -54,7 +54,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant title4', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="title4" />
+        <Typography accessibility="" variant="title4" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -63,7 +63,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant headline', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="headline" />
+        <Typography accessibility="" variant="headline" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -72,7 +72,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant subhead', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="subhead" />
+        <Typography accessibility="" variant="subhead" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -81,7 +81,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant footnote', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="footnote" />
+        <Typography accessibility="" variant="footnote" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -90,7 +90,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant caption1', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="caption1" />
+        <Typography accessibility="" variant="caption1" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();
@@ -99,7 +99,7 @@ describe('<Typography />', () => {
   it('should render and match snapshot for variant caption2', () => {
     const render = renderer.create(
       <ThemeProvider theme={theme}>
-        <Typography variant="caption2" />
+        <Typography accessibility="" variant="caption2" />
       </ThemeProvider>,
     );
     expect(render.toJSON()).toMatchSnapshot();

--- a/src/native/components/Typography/index.tsx
+++ b/src/native/components/Typography/index.tsx
@@ -12,7 +12,8 @@ const Typography: FC<TypographyType> = ({
   ...rest
 }) => (
   <Text
-    testID={id}
+    testID={id || accessibility}
+    accessibility={accessibility}
     accessibilityLabel={accessibility}
     ref={textRef}
     style={style}

--- a/src/native/types/Loading.ts
+++ b/src/native/types/Loading.ts
@@ -4,4 +4,5 @@ export interface LoadingType {
   large?: boolean;
   contrast?: boolean;
   variant?: LoadingVariants;
+  accessibility?: string;
 }

--- a/src/native/types/TextInputType.ts
+++ b/src/native/types/TextInputType.ts
@@ -5,7 +5,7 @@ import {
   TextStyle,
   KeyboardTypeOptions,
 } from 'react-native';
-import { TextInputMaskTypeProp } from 'react-native-masked-text';
+import { TextInputMaskTypeProp } from '@platformbuilders/react-native-masked-text';
 
 import { HitSlopType } from './Common';
 import { TypographyVariants } from './Variants';

--- a/src/native/types/TouchableType.ts
+++ b/src/native/types/TouchableType.ts
@@ -1,7 +1,7 @@
 import { HapticFeedbackType } from 'react-native-haptic';
 
 export interface TouchableType {
-  id: string;
+  id?: string;
   accessibility: string;
   accessibilityLabel?: string;
   testID?: string;

--- a/src/native/types/Typography.ts
+++ b/src/native/types/Typography.ts
@@ -26,6 +26,6 @@ export interface TypographyType {
   style?: StyleProp<TextStyle>;
   textRef?: any;
   id?: string;
-  accessibility?: string;
+  accessibility: string;
   numberOfLines?: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,6 +1688,14 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
+"@platformbuilders/react-native-masked-text@^1.0.0":
+  version "1.0.0"
+  resolved "https://npm.pkg.github.com/download/@platformbuilders/react-native-masked-text/1.0.0/4a7e5e1c6e7bcf40b61f865a6b6f0aded4152da64c4b0c95aaef0ec1b3e79de3#78b4c205e64dcfac6e2c62c3d22ede7faded4e77"
+  integrity sha512-gsaW2gwDkXepZr25rYa1p/GYp0oVKdYCsbV8M+3FHF0sdJrV02mIAsy0dMHdF88BkmgPvrCBeYyoEzQulpsbDQ==
+  dependencies:
+    date-and-time "0.14.2"
+    tinymask "1.0.2"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.2":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -6193,10 +6201,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-and-time@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.9.0.tgz#1524579e56dc07675c640b41735a7665c0659240"
-  integrity sha512-4JybB6PbR+EebpFx/KyR5Ybl+TcdXMLIJkyYsCx3P4M4CWGMuDyFF19yh6TyasMAIF5lrsgIxiSHBXh2FFc7Fg==
+date-and-time@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.14.2.tgz#a4266c3dead460f6c231fe9674e585908dac354e"
+  integrity sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA==
 
 dayjs@^1.8.15:
   version "1.9.8"
@@ -13136,13 +13144,6 @@ react-native-markdown-display@^6.1.6:
     markdown-it "^10.0.0"
     prop-types "^15.7.2"
     react-native-fit-image "^1.5.5"
-
-react-native-masked-text@duspada/react-native-masked-text:
-  version "1.13.0"
-  resolved "https://codeload.github.com/duspada/react-native-masked-text/tar.gz/298629bb4994c2c3bb4eebeeee4e93b74fc1194e"
-  dependencies:
-    date-and-time "0.9.0"
-    tinymask "1.0.2"
 
 react-native-responsive-fontsize@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
## O que foi feito? 📝
- adicionada a possibilidade de mandar apenas a prop 'accessibility' ao invés de ficar mandando diversas outras

## Link da estória no JIRA 🔗

<!-- cole o link do jira -->

## Screenshots ou GIFs 📸 

<!-- dica: use o KAP ou tire um print com cmd + shift + 5 -->

|-----Figma-----|-Implementação-|
|:-------------:|:-------------:|
|<!----aqui---->|<!----aqui---->|

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Está de acordo com os critérios de aceite da estória? ✅

- [ ] Resolve todos os critérios de aceite
- [ ] Resolve partes do critério de aceite
- [ ] Não resolve nenhum critério de aceite

## Checklist 🧐

<!-- mobile -->
- [x] Testado no iOS
- [ ] Testado no Android
<!-- web -->
- [ ] Testado no Chrome
- [ ] Testado no Safari
- [ ] Testado no Firefox
- [ ] Testado no Edge
- [ ] Não gerou alerta ou erro no console
