### PR TITLE
fix(button): variant and typographyvariant conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/react-elements",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Platform Builders Shared Components Library For React Web and Native",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/native/components/Button/index.tsx
+++ b/src/native/components/Button/index.tsx
@@ -29,7 +29,7 @@ const Button: FC<ButtonProps> = ({
       rounded={rounded}
     >
       <ButtonWrapper
-        variant={variant}
+        buttonVariant={variant}
         style={style}
         disabled={disabled}
         rounded={rounded}
@@ -41,6 +41,7 @@ const Button: FC<ButtonProps> = ({
               style={textStyle}
               disabled={disabled}
               variant={typographyVariant}
+              buttonVariant={variant}
             >
               {children}
             </TextButton>

--- a/src/native/components/Button/styles.ts
+++ b/src/native/components/Button/styles.ts
@@ -3,7 +3,7 @@ import { moderateScale } from 'react-native-size-matters';
 import TouchableComponent from '../Touchable';
 import TypographyComponent from '../Typography';
 import LoadingIndicator from '../LoadingIndicator';
-import { ButtonVariants } from '../../types';
+import { ButtonVariants, TypographyVariants } from '../../types';
 import { getTheme } from '../../utils/helpers';
 
 const disabledMain = getTheme('disabled.main');
@@ -21,7 +21,7 @@ const minimumSpacing = getTheme('minimumSpacing');
 
 type ButtonWrapperProps = {
   rounded: boolean;
-  variant: ButtonVariants;
+  buttonVariant: ButtonVariants;
   disabled?: boolean;
 };
 
@@ -31,7 +31,7 @@ const getBackgroundColor = (props: ButtonWrapperProps): string => {
   if (props.disabled) {
     return disabledMain(props);
   }
-  switch (props.variant) {
+  switch (props.buttonVariant) {
     case 'primary':
       return primaryMain(props);
     case 'secondary':
@@ -48,7 +48,8 @@ const getBackgroundColor = (props: ButtonWrapperProps): string => {
 };
 
 type TextButtonProps = {
-  variant: ButtonVariants;
+  buttonVariant: ButtonVariants;
+  variant?: TypographyVariants;
   disabled?: boolean;
 };
 
@@ -56,7 +57,7 @@ const getTextColor = (props: TextButtonProps): string => {
   if (props.disabled) {
     return disabledContrast(props);
   }
-  switch (props.variant) {
+  switch (props.buttonVariant) {
     case 'primary':
       return primaryContrast(props);
     case 'secondary':
@@ -93,7 +94,7 @@ export const ButtonWrapper = styled.View<ButtonWrapperProps>`
   background-color: ${getBackgroundColor};
   border-color: ${getTextColor};
   border: ${(props: ButtonWrapperProps) =>
-    props.variant === 'flat' ? `1px solid ${getTextColor(props)}` : '0'};
+    props.buttonVariant === 'flat' ? `1px solid ${getTextColor(props)}` : '0'};
 `;
 
 export const TextButton = styled(TypographyComponent)<TextButtonProps>`


### PR DESCRIPTION
## O que foi feito? 📝

No componente de typography quando chamavamos a função para pegar a cor do texto estava levando em consideração a variant e não o typographyVariant vindo dos parametros. Nisso a cor sempre caia no default.

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

<!-- mobile -->

- [x] Testado no iOS
- [ ] Testado no Android
