### PR TITLE
Add property "as" in Typography

### DIFF
--- a/documentation/docs/component.typography.md
+++ b/documentation/docs/component.typography.md
@@ -35,8 +35,9 @@ import { Typography } from '@platformbuilders/fluid-react';
 
 | Formato        | Conceito      | Tipo   |
 | ------|-----|-----|
-| **children?**  	| Elementos filhos do componente. 	| **React.ReactNode** 	|
-| **key?** 	| Define a chave do componente. 	| **number, string** 	|
-| **variant?** 	| É o que define a variação do que seria uma tag de texto em HTML, podendo ser: *button, caption, h1, h2, h3, h4, h5, h6, subtitle1, subtitle2, body1, body2, overline* . | **function** 	|
+| **children?**  	| Elementos filhos do componente. 	| **React.ReactNode** |
+| **key?** | Define a chave do componente. | **number, string** |
+| **variant?** | É o que define a variação do estilo, podendo ser: *min, xxs, xs, sm, md, lg, xl, xxl, max* . | **function** |
+| **as?** | Define a tag a ser renderizada ex: h1, h2, h3, h4, h5, h6, p, span entre outras tags | **string** |
 
 <!-- Documentation end -->


### PR DESCRIPTION
## O que foi feito? 📝

<!-- explicação do que foi feito -->

Adicionada propriedade "as" no componente de Tipograpfia

Não foi alterado o código, pois, essa é uma funcionalidade nativa do `styled-components` 

Exemplo da documentação: https://styled-components.com/docs/api#as-polymorphic-prop

## Screenshots ou GIFs 📸

<!-- dica: use o KAP ou tire um print com cmd + shift + 5 -->

<img width="289" alt="Screenshot 2023-07-07 at 16 01 20" src="https://github.com/platformbuilders/fluid-react/assets/7242605/13342a44-57ef-4ee9-8bb9-2013a62acf7a">

<img width="488" alt="Screenshot 2023-07-07 at 16 01 35" src="https://github.com/platformbuilders/fluid-react/assets/7242605/c9265321-3e32-43ce-9c75-cf331d4b462a">

Resultado do Markdown

<img width="726" alt="Screenshot 2023-07-07 at 16 04 01" src="https://github.com/platformbuilders/fluid-react/assets/7242605/9dbfd907-011f-4020-b364-5c903035d761">

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código)
- [x] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [ ] Testado no Yalc
- [ ] Testado no Chrome
- [ ] Testado no Safari
