### PR TITLE
Fix styled props passed to DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "description": "Builders React for Fluid Design System",
   "keywords": [
@@ -46,6 +46,7 @@
   "dependencies": {
     "@material-ui/core": "4.12.4",
     "@material-ui/lab": "4.0.0-alpha.60",
+    "@platformbuilders/helpers": "0.8.2",
     "@platformbuilders/theme-toolkit": "0.2.6",
     "numeral": "2.0.6",
     "patch-package": "7.0.0",
@@ -59,7 +60,6 @@
     "@commitlint/config-conventional": "17.0.3",
     "@faker-js/faker": "7.4.0",
     "@platformbuilders/eslint-config-builders": "0.1.2",
-    "@platformbuilders/helpers": "0.8.2",
     "@rollup/plugin-image": "2.1.1",
     "@rollup/plugin-json": "4.1.0",
     "@storybook/addon-actions": "6.5.10",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -40,7 +40,7 @@ const Button: FC<ButtonProps> = ({
             style={textStyle}
             disabled={disabled}
             variant={typographyVariant}
-            buttonVariant={variant}
+            $buttonVariant={variant}
           >
             {children}
           </TextButton>

--- a/src/components/Button/styles.tsx
+++ b/src/components/Button/styles.tsx
@@ -59,7 +59,8 @@ export const Touchable = styled(TouchableComponent)<ButtonWrapperProps>`
 
 export const TextButton = styled(TypographyComponent)<any>`
   letter-spacing: 0.4px;
-  color: ${(props) => getTextColor({ ...props, variant: props.buttonVariant })};
+  color: ${(props) =>
+    getTextColor({ ...props, variant: props.$buttonVariant })};
 `;
 
 export const Loading = styled(LoadingIndicator).attrs({

--- a/src/components/Typography/__tests__/typography.spec.tsx
+++ b/src/components/Typography/__tests__/typography.spec.tsx
@@ -4,10 +4,10 @@ import { render } from '@testing-library/react';
 
 import Typography from '..';
 import theme from '../../../theme';
-import { TypographyType as Props } from '../../../types';
+import { TypographyTypeProps } from '../../../types';
 
 const defaultContent = 'Text';
-const defaultProps: Props = {};
+const defaultProps: TypographyTypeProps = {};
 
 describe('Component: Typography', () => {
   test('snapshots', () => {

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,14 +1,14 @@
 import { FC } from 'react';
-import { TypographyType } from '../../types';
+import { TypographyTypeProps } from '../../types';
 import { Text } from './styles';
 
-const Typography: FC<TypographyType> = ({
+const Typography: FC<TypographyTypeProps> = ({
   variant = 'md',
   lineHeightVariant = 'min',
   children,
   ...rest
 }) => (
-  <Text variant={variant} lineHeightVariant={lineHeightVariant} {...rest}>
+  <Text variant={variant} $lineHeightVariant={lineHeightVariant} {...rest}>
     {children}
   </Text>
 );

--- a/src/components/Typography/styles.tsx
+++ b/src/components/Typography/styles.tsx
@@ -4,10 +4,15 @@ import {
   getLineHeight,
   getTheme,
 } from '@platformbuilders/theme-toolkit';
-import { TypographyType } from '../../types';
+import { TypographyTypeStyleProps } from '../../types';
 
-export const Text = styled.p<TypographyType>`
+export const Text = styled.p<TypographyTypeStyleProps>`
   color: ${getTheme('text.main')};
   font-size: ${getFontSize}px;
-  line-height: ${getLineHeight}px;
+  line-height: ${(props) => {
+    return getLineHeight({
+      ...props,
+      lineHeightVariant: props.$lineHeightVariant,
+    });
+  }}px;
 `;

--- a/src/types/Typography.ts
+++ b/src/types/Typography.ts
@@ -1,10 +1,17 @@
 import { PropsWithChildren } from 'react';
 import { TypographyVariants } from '@platformbuilders/theme-toolkit';
 
-export type TypographyType = PropsWithChildren<{
+type TypographyTypeBase = PropsWithChildren<{
   variant?: TypographyVariants;
-  lineHeightVariant?: TypographyVariants;
   id?: string;
   accessibility?: string;
   numberOfLines?: number;
 }>;
+
+export type TypographyTypeProps = TypographyTypeBase & {
+  lineHeightVariant?: TypographyVariants;
+};
+
+export type TypographyTypeStyleProps = TypographyTypeBase & {
+  $lineHeightVariant?: TypographyVariants;
+};


### PR DESCRIPTION
## O que foi feito? 📝

<!-- explicação do que foi feito -->

Corrigido console.error por conta das propriedades passadas para o styled-components serem renderizadas no DOM

## Screenshots ou GIFs 📸

<!-- dica: use o KAP ou tire um print com cmd + shift + 5 -->

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [ ] Testado no Yalc
- [ ] Testado no Chrome
- [ ] Testado no Safari
