### PR TITLE
Add `radio button` without usage of `material ui`

### DIFF
--- a/src/components/Radio/__test__/__snapshots__/radio.spec.tsx.snap
+++ b/src/components/Radio/__test__/__snapshots__/radio.spec.tsx.snap
@@ -2,16 +2,42 @@
 
 exports[`Component: Radio snapshots with another props 1`] = `
 <div>
-  <label>
-    Text
-  </label>
+  <div
+    class="sc-bcHOTY czukwj"
+  >
+    <input
+      class="sc-gsMHZj kErQid"
+      id="id1"
+      name="group1"
+      type="radio"
+    />
+    <label
+      class="sc-dkHyXG hMzduA"
+      for="id1"
+    >
+      TEXT
+    </label>
+  </div>
 </div>
 `;
 
 exports[`Component: Radio snapshots with default props 1`] = `
 <div>
-  <label>
-    Text
-  </label>
+  <div
+    class="sc-bcHOTY czukwj"
+  >
+    <input
+      class="sc-gsMHZj kErQid"
+      id="id1"
+      name="group1"
+      type="radio"
+    />
+    <label
+      class="sc-dkHyXG hMzduA"
+      for="id1"
+    >
+      Text
+    </label>
+  </div>
 </div>
 `;

--- a/src/components/Radio/__test__/radio.spec.tsx
+++ b/src/components/Radio/__test__/radio.spec.tsx
@@ -3,13 +3,14 @@ import { render } from '@testing-library/react';
 
 import Radio from '..';
 import theme from '../../../theme';
-import { RadioProps as Props } from '../../../types';
+import { Props } from '../index';
 
 const defaultContent = 'Text';
 const defaultProps: Props = {
-  checked: true,
   label: defaultContent,
   onChange: jest.fn(),
+  group: 'group1',
+  id: 'id1',
 };
 
 describe('Component: Radio', () => {
@@ -26,7 +27,7 @@ describe('Component: Radio', () => {
     const valueMock = 'TEXT';
     const { container } = render(
       <ThemeProvider theme={theme}>
-        <Radio {...defaultProps} size="medium" value={valueMock} />
+        <Radio {...defaultProps} label={valueMock} />
       </ThemeProvider>,
     );
     expect(container).toMatchSnapshot();

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,4 +1,19 @@
-import styled from 'styled-components';
-import { RadioProps } from '../../types';
+import { ChangeEvent, FC } from 'react';
 
-export default styled(({ label }) => <label>{label}</label>)<RadioProps>``;
+import { Input, Label, Wrapper } from './styles';
+
+export type Props = {
+  id: string;
+  label: string;
+  group: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+
+const Radio: FC<Props> = ({ onChange, id, label, group }) => (
+  <Wrapper>
+    <Input onChange={onChange} id={id} name={group} type="radio" />
+    <Label htmlFor={id}>{label}</Label>
+  </Wrapper>
+);
+
+export default Radio;

--- a/src/components/Radio/styles.ts
+++ b/src/components/Radio/styles.ts
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  margin: 16px 0;
+`;
+
+export const Input = styled.input`
+  display: none;
+  &:checked + label:before {
+    border-color: rgb(51, 122, 183);
+    animation: ripple 0.2s linear forwards;
+  }
+  &:checked + label:after {
+    transform: scale(1);
+  }
+`;
+
+export const Label = styled.label`
+  display: inline-block;
+  min-height: 20px;
+  position: relative;
+  padding: 0 30px;
+  margin-bottom: 0;
+  cursor: pointer;
+  vertical-align: bottom;
+
+  @keyframes ripple {
+    0% {
+      box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0);
+    }
+    50% {
+      box-shadow: 0px 0px 0px 15px rgba(0, 0, 0, 0.1);
+    }
+    100% {
+      box-shadow: 0px 0px 0px 15px rgba(0, 0, 0, 0);
+    }
+  }
+
+  &:before,
+  &:after {
+    position: absolute;
+    content: '';
+    border-radius: 50%;
+    transition: all 0.3s ease;
+    transition-property: transform, border-color;
+  }
+
+  &:before {
+    left: 0;
+    top: 0;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(0, 0, 0, 0.54);
+  }
+
+  &:after {
+    top: 5px;
+    left: 5px;
+    width: 10px;
+    height: 10px;
+    transform: scale(0);
+    background: rgb(51, 122, 183);
+  }
+`;

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -1,26 +1,20 @@
-import { FC, useState } from 'react';
+import { ChangeEvent, FC } from 'react';
 import { Input, Label, Wrapper } from './styles';
 
 type Props = {
   id: string;
   label: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  checked?: boolean;
 };
 
-const Switch: FC<Props> = ({ id, label }) => {
-  const [checked, setChecked] = useState(false);
-
-  const handleChangeChecked = () => {
-    setChecked((prevState) => !prevState);
-  };
-
-  return (
-    <Wrapper>
-      <Input type="checkbox" id={id} onChange={handleChangeChecked} />
-      <Label htmlFor={id} checked={checked}>
-        {label}
-      </Label>
-    </Wrapper>
-  );
-};
+const Switch: FC<Props> = ({ id, label, onChange, checked = false }) => (
+  <Wrapper>
+    <Input type="checkbox" id={id} onChange={onChange} />
+    <Label htmlFor={id} checked={checked}>
+      {label}
+    </Label>
+  </Wrapper>
+);
 
 export default Switch;


### PR DESCRIPTION
## O que foi feito? 📝

<!-- explicação do que foi feito -->

Adicionado `radio button` sem a utilização do `material ui`

## Screenshots ou GIFs 📸

<!-- dica: use o KAP ou tire um print com cmd + shift + 5 -->

[radio.webm](https://github.com/platformbuilders/fluid-react/assets/7242605/14df7a57-fc12-4a0b-a3f7-58ee993414fb)


## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [x] Refactor (mudança non-breaking que melhora o código)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [x] Testado no Yalc
- [x] Testado no Chrome
- [x] Testado no Safari
