### PR TITLE
Export SelectOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "description": "Builders React for Fluid Design System",
   "keywords": [

--- a/src/components/Avatar/__tests__/avatar.spec.tsx
+++ b/src/components/Avatar/__tests__/avatar.spec.tsx
@@ -6,7 +6,7 @@ import theme from '../../../theme';
 const defaultProps: Props = {
   src: 'some_url',
   alt: 'some image',
-  onClick: jest.fn(),
+  onPress: jest.fn(),
 };
 
 describe('Component: Avatar', () => {

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -6,12 +6,12 @@ export type Props = {
   src: string;
   alt: string;
   variant?: AvatarVariants;
-  onClick(): void;
+  onPress(): void;
 };
 
-const Avatar: FC<Props> = ({ src, onClick, alt, variant }) => (
+const Avatar: FC<Props> = ({ src, onPress, alt, variant }) => (
   <Wrapper $variant={variant}>
-    <Image alt={alt} src={src} onClick={onClick} />
+    <Image alt={alt} src={src} onClick={onPress} />
   </Wrapper>
 );
 

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -6,6 +6,7 @@ import {
   ScrollUpButton,
   Value,
 } from '@radix-ui/react-select';
+import { SelectOptions } from '../../types';
 import {
   PlaceholderText,
   StyledContent,
@@ -16,14 +17,9 @@ import {
   Wrapper,
 } from './styles';
 
-type Options = {
-  option: string;
-  value: string;
-};
-
 type Props = {
   id: string;
-  options: Options[];
+  options: SelectOptions[];
   disabled?: boolean;
   helperMessage?: string;
   label?: string;

--- a/src/types/Select.ts
+++ b/src/types/Select.ts
@@ -1,0 +1,4 @@
+export type SelectOptions = {
+  option: string;
+  value: string;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './Switch';
 export * from './LazyWrapper';
 export * from './Typography';
 export * from './TouchableType';
+export * from './Select';


### PR DESCRIPTION
## O que foi feito? 📝

<!-- explicação do que foi feito -->
Exportando o tipo SelectOptions
Prop onClick do componente Select renomeado para onPress
## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [ ] Testado no Yalc
- [ ] Testado no Chrome
- [ ] Testado no Safari
