### PR TITLE
feat(text-input): add all props of input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "description": "Builders React for Fluid Design System",
   "keywords": [

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,4 +1,12 @@
-import { ChangeEvent, FC, FocusEvent, Ref, RefObject, useRef } from 'react';
+import {
+  ChangeEvent,
+  FC,
+  FocusEvent,
+  InputHTMLAttributes,
+  Ref,
+  RefObject,
+  useRef,
+} from 'react';
 import { IMaskMixin, ReactElementProps } from 'react-imask';
 
 import { Input, Label, Message, PlaceholderLabel, Wrapper } from './styles';
@@ -18,7 +26,7 @@ const InputMask = IMaskMixin(
   ),
 );
 
-export type TextInputType = {
+export type TextInputType = InputHTMLAttributes<HTMLInputElement> & {
   style?: any;
   textInputStyle?: any;
   maskOptions?: any;
@@ -60,6 +68,7 @@ const TextInput: FC<TextInputType> = ({
   maxLength,
   autoFocus,
   maskOptions,
+  ...rest
 }) => {
   const hasValue = value?.length > 0;
   const hasError = error ? error.length > 0 : false;
@@ -100,6 +109,7 @@ const TextInput: FC<TextInputType> = ({
             maxLength={maxLength}
             autoFocus={autoFocus}
             $hasError={hasError}
+            {...rest}
           />
         )}
         <PlaceholderLabel $hasError={hasError} $hasValue={hasValue}>


### PR DESCRIPTION
## O que foi feito? 📝

Adicionado todas as props do input, para mais liberdade na utilização do componente possibilitando passar atributos como `type`

## Tipo de mudança 🏗

- [x] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [x] Testado no Yalc
- [x] Testado no Chrome
- [x] Testado no Safari
