### PR TITLE
Correção na estilização do input "outlined" quando desabilitado

### DIFF
--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -4,6 +4,7 @@ import {
   FocusEvent,
   InputHTMLAttributes,
   MouseEvent,
+  forwardRef,
   useRef,
   useState,
 } from 'react';
@@ -56,194 +57,210 @@ export type TextInputType = InputHTMLAttributes<HTMLInputElement> &
       | undefined;
   };
 
-const TextInput: FC<TextInputType> = ({
-  message,
-  error,
-  onChange,
-  onBlur,
-  onFocus,
-  onClickIconLeft,
-  onClickIconRight,
-  style,
-  label,
-  textInputStyle,
-  value,
-  id,
-  name,
-  maxLength,
-  autoFocus,
-  maskOptions,
-  iconRight,
-  iconLeft,
-  variant = 'default',
-  ...rest
-}) => {
-  const [isFocused, setIsFocused] = useState(false);
+const TextInput: FC<TextInputType> = forwardRef<
+  HTMLInputElement,
+  TextInputType
+>(
+  (
+    {
+      message,
+      error,
+      onChange,
+      onBlur,
+      onFocus,
+      onClickIconLeft,
+      onClickIconRight,
+      style,
+      label,
+      textInputStyle,
+      value,
+      id,
+      name,
+      maxLength,
+      autoFocus,
+      maskOptions,
+      iconRight,
+      iconLeft,
+      variant = 'default',
+      ...rest
+    },
+    ref,
+  ) => {
+    const [isFocused, setIsFocused] = useState(false);
 
-  const hasValue = value?.length > 0;
-  const hasError = error ? error.length > 0 : false;
-  const hasFocus = isFocused || hasValue;
+    const hasValue = value?.length > 0;
+    const hasError = error ? error.length > 0 : false;
+    const hasFocus = isFocused || hasValue;
 
-  const RightIconComponent: any = iconRight && Icons[iconRight];
-  const LeftIconComponent: any = iconLeft && Icons[iconLeft];
-  const ErrorIconComponent: any = Icons['ExclamationTriangleIcon'];
+    const RightIconComponent: any = iconRight && Icons[iconRight];
+    const LeftIconComponent: any = iconLeft && Icons[iconLeft];
+    const ErrorIconComponent: any = Icons['ExclamationTriangleIcon'];
 
-  const onAccept = (value: any) => {
-    if (onChange) {
-      onChange({
-        target: {
-          name,
-          value,
-        },
-      } as any);
-    }
-  };
+    const onAccept = (value: any) => {
+      if (onChange) {
+        onChange({
+          target: {
+            name,
+            value,
+          },
+        } as any);
+      }
+    };
 
-  const handleFocus = () => {
-    setIsFocused(true);
-  };
+    const handleFocus = () => {
+      setIsFocused(true);
+    };
 
-  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
-    if (event.target.value === '') {
-      setIsFocused(false);
-    }
-  };
+    const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+      if (event.target.value === '') {
+        setIsFocused(false);
+      }
+    };
 
-  const ref = useRef(null);
-  const inputRef = useRef(null);
+    const inputRef = useRef<HTMLInputElement>(null);
 
-  return (
-    <Wrapper style={style}>
-      {variant === 'outlined' && (
-        <Label
-          htmlFor={id}
+    return (
+      <Wrapper style={style} $variant={variant}>
+        {variant === 'outlined' && (
+          <Label
+            htmlFor={id}
+            $hasFocus={hasFocus}
+            $hasError={hasError}
+            $hasIconLeft={!!iconLeft}
+            $hasIconRight={!!iconRight}
+            $isDisabled={rest.disabled}
+          >
+            {label}
+          </Label>
+        )}
+
+        <InputWrapper
           $hasFocus={hasFocus}
           $hasError={hasError}
-          $hasIconLeft={!!iconLeft}
-          $hasIconRight={!!iconRight}
-        >
-          {label}
-        </Label>
-      )}
-
-      <InputWrapper
-        $hasFocus={hasFocus}
-        $hasError={hasError}
-        $variant={variant}
-      >
-        {iconLeft && (
-          <IconWrapperLeft
-            $clickable={!!onClickIconLeft}
-            $hasError={hasError}
-            onClick={onClickIconLeft}
-          >
-            <LeftIconComponent
-              id={`${id}-left-icon`}
-              accessibility="ícone do botão"
-            />
-          </IconWrapperLeft>
-        )}
-
-        {maskOptions ? (
-          <StyledIMaskInput
-            {...maskOptions}
-            id={id}
-            name={name}
-            data-testid={id}
-            style={textInputStyle}
-            ref={ref}
-            inputRef={inputRef}
-            onAccept={onAccept}
-            autoFocus={autoFocus}
-            hasError={hasError}
-            onFocus={(event) => {
-              handleFocus();
-              onFocus?.(event);
-            }}
-            onBlur={(event) => {
-              handleBlur(event);
-              onBlur?.(event);
-            }}
-            mask={hasFocus ? maskOptions?.mask : ''}
-            defaultValue={value}
-            $hasIconLeft={!!iconLeft}
-            $hasIconRight={!!iconRight}
-            $hasError={hasError}
-            $variant={variant}
-            {...rest}
-          />
-        ) : (
-          <Input
-            id={id}
-            data-testid={id}
-            name={name}
-            value={value}
-            style={textInputStyle}
-            onFocus={(event) => {
-              handleFocus();
-              onFocus?.(event);
-            }}
-            onBlur={(event) => {
-              handleBlur(event);
-              onBlur?.(event);
-            }}
-            onChange={onChange}
-            maxLength={maxLength}
-            autoFocus={autoFocus}
-            $hasError={hasError}
-            $hasIconLeft={!!iconLeft}
-            $hasIconRight={!!iconRight}
-            $variant={variant}
-            {...rest}
-          />
-        )}
-
-        {iconRight && (
-          <IconWrapperRight
-            $clickable={!!onClickIconRight}
-            $hasError={hasError}
-            onClick={onClickIconRight}
-          >
-            <RightIconComponent
-              id={`${id}-right-icon`}
-              accessibility="ícone do botão"
-            />
-          </IconWrapperRight>
-        )}
-
-        {variant === 'outlined' && (
-          <Fieldset $hasFocus={hasFocus} $hasError={hasError}>
-            <legend>
-              <span>{label}</span>
-            </legend>
-          </Fieldset>
-        )}
-      </InputWrapper>
-
-      {variant !== 'outlined' && (
-        <PlaceholderLabel
-          className="text-input-label"
-          $hasIconLeft={!!iconLeft}
-          $hasIconRight={!!iconRight}
-          $hasError={hasError}
-          $hasValue={hasValue}
-        >
-          {label}
-        </PlaceholderLabel>
-      )}
-
-      {error || message ? (
-        <Message
-          className="error-text-input"
-          $hasError={hasError}
           $variant={variant}
+          $isDisabled={rest.disabled}
         >
-          {variant === 'outlined' && <ErrorIconComponent />}
-          {error || message}
-        </Message>
-      ) : null}
-    </Wrapper>
-  );
-};
+          {iconLeft && (
+            <IconWrapperLeft
+              $clickable={!!onClickIconLeft}
+              $hasError={hasError}
+              onClick={onClickIconLeft}
+            >
+              <LeftIconComponent
+                id={`${id}-left-icon`}
+                accessibility="ícone do botão"
+              />
+            </IconWrapperLeft>
+          )}
+
+          {maskOptions ? (
+            <StyledIMaskInput
+              {...maskOptions}
+              id={id}
+              name={name}
+              data-testid={id}
+              style={textInputStyle}
+              ref={ref}
+              inputRef={inputRef}
+              onAccept={onAccept}
+              autoFocus={autoFocus}
+              hasError={hasError}
+              onFocus={(event) => {
+                handleFocus();
+                onFocus?.(event);
+              }}
+              onBlur={(event) => {
+                handleBlur(event);
+                onBlur?.(event);
+              }}
+              mask={hasFocus ? maskOptions?.mask : ''}
+              defaultValue={value}
+              $hasIconLeft={!!iconLeft}
+              $hasIconRight={!!iconRight}
+              $hasError={hasError}
+              $variant={variant}
+              $isDisabled={rest.disabled}
+              {...rest}
+            />
+          ) : (
+            <Input
+              id={id}
+              data-testid={id}
+              name={name}
+              value={value}
+              style={textInputStyle}
+              ref={ref}
+              onFocus={(event) => {
+                handleFocus();
+                onFocus?.(event);
+              }}
+              onBlur={(event) => {
+                handleBlur(event);
+                onBlur?.(event);
+              }}
+              onChange={onChange}
+              maxLength={maxLength}
+              autoFocus={autoFocus}
+              $hasError={hasError}
+              $hasIconLeft={!!iconLeft}
+              $hasIconRight={!!iconRight}
+              $variant={variant}
+              $isDisabled={rest.disabled}
+              {...rest}
+            />
+          )}
+
+          {iconRight && (
+            <IconWrapperRight
+              $clickable={!!onClickIconRight}
+              $hasError={hasError}
+              onClick={onClickIconRight}
+            >
+              <RightIconComponent
+                id={`${id}-right-icon`}
+                accessibility="ícone do botão"
+              />
+            </IconWrapperRight>
+          )}
+
+          {variant === 'outlined' && (
+            <Fieldset
+              $hasFocus={hasFocus}
+              $hasError={hasError}
+              $isDisabled={rest.disabled}
+            >
+              <legend>
+                <span>{label}</span>
+              </legend>
+            </Fieldset>
+          )}
+        </InputWrapper>
+
+        {variant !== 'outlined' && (
+          <PlaceholderLabel
+            className="text-input-label"
+            $hasIconLeft={!!iconLeft}
+            $hasIconRight={!!iconRight}
+            $hasError={hasError}
+            $hasValue={hasValue}
+          >
+            {label}
+          </PlaceholderLabel>
+        )}
+
+        {error || message ? (
+          <Message
+            className="error-text-input"
+            $hasError={hasError}
+            $variant={variant}
+          >
+            {variant === 'outlined' && <ErrorIconComponent />}
+            {error || message}
+          </Message>
+        ) : null}
+      </Wrapper>
+    );
+  },
+);
 
 export default TextInput;

--- a/src/components/TextInput/styles.tsx
+++ b/src/components/TextInput/styles.tsx
@@ -20,11 +20,13 @@ type MessageProps = VariantProps & {
 
 type InputProps = VariantProps & {
   $hasError: boolean;
+  $isDisabled?: boolean;
 } & HasIcon;
 
 type InputWrapperProps = VariantProps & {
   $hasFocus: boolean;
   $hasError: boolean;
+  $isDisabled?: boolean;
 };
 
 type IconProps = {
@@ -35,7 +37,14 @@ type IconProps = {
 type LabelProps = {
   $hasFocus: boolean;
   $hasError: boolean;
+  $isDisabled?: boolean;
 } & HasIcon;
+
+type FieldsetProps = {
+  $hasFocus: boolean;
+  $hasError: boolean;
+  $isDisabled?: boolean;
+};
 
 const primaryMain = getTheme('brand.primary.main');
 const dangerMain = getTheme('danger.main');
@@ -63,6 +72,7 @@ const inputOutlinedStyles = ({
   height: 30px;
   padding: 0;
   background: transparent;
+  margin-bottom: 0;
 
   ${$hasIconRight && `padding-right: ${pxToRem(36)};`}
   ${$hasIconLeft && `padding-left: ${pxToRem(36)};`}
@@ -70,6 +80,10 @@ const inputOutlinedStyles = ({
 
   &::placeholder {
     color: transparent;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
   }
 `;
 
@@ -154,8 +168,9 @@ export const Message = styled.p<MessageProps>`
     `};
 `;
 
-export const Wrapper = styled.div`
-  margin-bottom: ${spacingLg}px;
+export const Wrapper = styled.div<VariantProps>`
+  margin-bottom: ${({ $variant }) =>
+    $variant === 'outlined' ? `0` : `${spacingLg}px`};
   position: relative;
 `;
 
@@ -197,10 +212,16 @@ export const Label = styled.label<LabelProps>`
       color: ${hasError(dangerMain, primaryMain)};
       padding: 0 ${pxToRem(4)};
     `}
+
+    ${({ $isDisabled }) =>
+    $isDisabled &&
+    css`
+      opacity: 0.5;
+    `}
 `;
 
 export const InputWrapper = styled.div<InputWrapperProps>`
-  ${({ $variant, $hasFocus }) =>
+  ${({ $variant, $hasFocus, $isDisabled }) =>
     $variant === 'outlined' &&
     css`
       position: relative;
@@ -213,16 +234,16 @@ export const InputWrapper = styled.div<InputWrapperProps>`
       border: ${$hasFocus ? 'none' : `1px solid #10141633`};
       border-color: ${hasError(dangerMain, '')};
 
+      ${$isDisabled && `opacity: 0.5`};
+
       &:hover {
         border-color: ${hasError(dangerMain, primaryMain)};
+        ${$isDisabled && `border-color: #10141633`};
       }
     `}
 `;
 
-export const Fieldset = styled.fieldset<{
-  $hasFocus: boolean;
-  $hasError: boolean;
-}>`
+export const Fieldset = styled.fieldset<FieldsetProps>`
   position: absolute;
   top: ${pxToRem(-5)};
   left: ${pxToRem(-1)};
@@ -235,6 +256,12 @@ export const Fieldset = styled.fieldset<{
   pointer-events: none;
   display: ${({ $hasFocus }) => !$hasFocus && 'none'};
 
+  ${({ $isDisabled }) =>
+    $isDisabled &&
+    css`
+      border: 1px solid #10141633;
+    `}
+
   legend {
     width: auto;
     padding: 0 ${pxToRem(5)};
@@ -244,7 +271,7 @@ export const Fieldset = styled.fieldset<{
     color: ${hasError(dangerMain, primaryMain)};
 
     span {
-      visibility: ${(props) => props.$hasFocus && 'hidden'};
+      visibility: ${({ $hasFocus }) => $hasFocus && 'hidden'};
     }
   }
 `;

--- a/src/components/TextInput/text-input.stories.tsx
+++ b/src/components/TextInput/text-input.stories.tsx
@@ -38,6 +38,10 @@ const meta: Meta<typeof TextInput> = {
       type: 'string',
       defaultValue: 'default',
     },
+    disabled: {
+      type: 'boolean',
+      defaultValue: false,
+    },
   },
   args: {
     id: mockTextId,
@@ -48,6 +52,7 @@ const meta: Meta<typeof TextInput> = {
     onFocus: events.onFocus,
     onClickIconLeft: events.onClickIconLeft,
     variant: 'default',
+    disabled: false,
   },
   tags: ['autodocs'],
 };


### PR DESCRIPTION
## O que foi feito? 📝

A estilização do input com a variant "outlined" estava errada, além do comportamento de hover do input. Isso estava atrapalhando a identificação dos campos desabilitados.

## Screenshots ou GIFs 📸
Antes da alteração:
![image](https://github.com/user-attachments/assets/73f2d0fa-1c15-4991-9535-af6b74dc5aed)

Após a alteração:
![image](https://github.com/user-attachments/assets/78059fae-c31c-4d3f-9029-45cef6be6a3c)

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [X] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [X] Testado no Yalc
- [X] Testado no Chrome
- [ ] Testado no Safari
