### PR TITLE
Correção do placeholder na variant "outlined"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "private": false,
   "description": "Builders React for Fluid Design System",
   "keywords": [

--- a/src/components/TextInput/styles.tsx
+++ b/src/components/TextInput/styles.tsx
@@ -236,6 +236,16 @@ export const InputWrapper = styled.div<InputWrapperProps>`
 
       ${$isDisabled && `opacity: 0.5`};
 
+      ${$hasFocus &&
+      css`
+        input {
+          &::placeholder {
+            color: ${textMain};
+            opacity: 0.5;
+          }
+        }
+      `}
+
       &:hover {
         border-color: ${hasError(dangerMain, primaryMain)};
         ${$isDisabled && `border-color: #10141633`};


### PR DESCRIPTION
## O que foi feito? 📝

O placeholder não estava aparecendo na variant "outlined" do TextInput. Foi feita a correção disso.

## Screenshots ou GIFs 📸

![image](https://github.com/user-attachments/assets/a554d406-387f-4a6a-8604-b8352bc4af54)


## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [X] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [X] Testado no Yalc
- [X] Testado no Chrome
- [ ] Testado no Safari
