### PR TITLE
refactor: add new type to iconRight

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "private": false,
   "description": "Builders React for Fluid Design System",
   "keywords": [

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -4,6 +4,7 @@ import {
   FocusEvent,
   InputHTMLAttributes,
   MouseEvent,
+  ReactNode,
   forwardRef,
   useRef,
   useState,
@@ -38,7 +39,7 @@ export type TextInputType = InputHTMLAttributes<HTMLInputElement> &
     maxLength?: number;
     value: string;
     autoFocus?: boolean;
-    iconRight?: IconsType;
+    iconRight?: IconsType | Exclude<ReactNode, string | IconsType>;
     iconLeft?: IconsType;
     onClickIconRight?: (event: MouseEvent<HTMLElement>) => void;
     onClickIconLeft?: (event: MouseEvent<HTMLElement>) => void;
@@ -92,7 +93,10 @@ const TextInput: FC<TextInputType> = forwardRef<
     const hasError = error ? error.length > 0 : false;
     const hasFocus = isFocused || hasValue;
 
-    const RightIconComponent: any = iconRight && Icons[iconRight];
+    const RightIconComponent: any =
+      typeof iconRight === 'string' && iconRight in Icons
+        ? Icons[iconRight as IconsType]
+        : null;
     const LeftIconComponent: any = iconLeft && Icons[iconLeft];
     const ErrorIconComponent: any = Icons['ExclamationTriangleIcon'];
 
@@ -216,10 +220,14 @@ const TextInput: FC<TextInputType> = forwardRef<
               $hasError={hasError}
               onClick={onClickIconRight}
             >
-              <RightIconComponent
-                id={`${id}-right-icon`}
-                accessibility="ícone do botão"
-              />
+              {RightIconComponent ? (
+                <RightIconComponent
+                  id={`${id}-right-icon`}
+                  accessibility="ícone do botão"
+                />
+              ) : (
+                iconRight
+              )}
             </IconWrapperRight>
           )}
 


### PR DESCRIPTION
## O que foi feito? 📝

Foi adicionado mais uma tipagem para o iconRight, para tornar de certa forma mais customizável. Da forma atual, só era possível termos um ícone.

## Screenshots ou GIFs 📸

![image](https://github.com/user-attachments/assets/a6f4a736-431b-408d-82fa-9530c6d2db92)

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [X] Refactor (mudança non-breaking que melhora o código)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [X] Testado no Yalc
- [X] Testado no Chrome
- [ ] Testado no Safari
