### PR TITLE
adjust calendar open this icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/fluid-react",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "private": false,
   "description": "Builders React for Fluid Design System",
   "keywords": [

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta<typeof DatePicker> = {
     minDate: { control: { type: 'boolean' } },
     maxDate: { control: { type: 'boolean' } },
     inputVariant: { type: 'string' },
+    disabledInput: { control: { type: 'boolean' } },
   },
   args: {
     onChange: onChange,

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -16,6 +16,7 @@ interface Props extends DatePickerProps {
   workDays?: boolean;
   holidays?: string[];
   inputVariant?: 'default' | 'outlined';
+  disabledInput?: boolean;
 }
 
 const DatePickerComponent: React.FC<Props> = ({
@@ -30,6 +31,7 @@ const DatePickerComponent: React.FC<Props> = ({
   name,
   id,
   inputVariant = 'outlined',
+  disabledInput = false,
 }) => {
   const datePickerRef = useRef();
   return (
@@ -43,8 +45,9 @@ const DatePickerComponent: React.FC<Props> = ({
             id={id}
             value={value}
             onClick={openCalendar}
-            onChange={(e) => onChange(e)}
+            onChange={(e) => (disabledInput ? value : onChange(e))}
             iconRight="ChevronDownIcon"
+            onClickIconRight={openCalendar}
             variant={inputVariant}
           />
         );


### PR DESCRIPTION
## O que foi feito? 📝

* Foi inserido a opção de não poder inserir qualquer texto no componente de calendario e sim somente selecionar uma data
* Foi inserido a opção de abrir o calendario quando clicar no icone e não somente no input

## Screenshots ou GIFs 📸

https://github.com/user-attachments/assets/18e0721c-40fd-46da-ac79-12d47d0003eb


## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [x] Refactor (mudança non-breaking que melhora o código)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [x] Testado no Yalc
- [x] Testado no Chrome
- [x] Testado no Safari
